### PR TITLE
chore: upgrade to Node.js 22

### DIFF
--- a/.github/workflows/publish-on-push.yml
+++ b/.github/workflows/publish-on-push.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Upgrade npm for trusted publishing

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn storybook
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/en/download/) >=20.11.1
+- [Node.js](https://nodejs.org/en/download/) >=22
 - [yarn](https://yarnpkg.com/getting-started/install) >=4.9.4
 
 ### Running locally

--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "@navikt/aksel-icons": "^7.39.0",
     "classnames": "^2.5.1"
   },
-  "packageManager": "yarn@4.9.4"
+  "packageManager": "yarn@4.9.4",
+  "engines": {
+    "node": ">=22"
+  }
 }


### PR DESCRIPTION
## Summary fixes #132

- Upgrade Node.js requirement from 20 to 22
- Update GitHub Actions workflow to use Node.js 22
- Add `engines` field to package.json to enforce version requirement
- Update documentation in README.md