### PR TITLE
chore: pin postcss to fix XSS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ajv": ">=8.18.0",
     "glob": ">10.5.0",
     "minimatch": ">=10.2.3",
+    "postcss": ">=8.5.10",
     "vite": "^8.0.8"
   },
   "packageManager": "yarn@4.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,14 +3124,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.8":
-  version: 8.5.9
-  resolution: "postcss@npm:8.5.9"
+"postcss@npm:>=8.5.10":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7cb2b32202ea1ead03f15cfbb2756a64a0f98942378e99b3dfce33678fe5eaf93e31d675a46e3a0dfb417d7b49b82d8999d0dd42a33c3b128e71ade0f978719a
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
  - Add `postcss: >=8.5.10` resolution to fix GHSA-qx2v-qp2m-jg93 (XSS via unescaped </style> in CSS stringify output) 
  - Upgrades postcss from 8.5.9 to 8.5.12 in yarn.lock    