### PR TITLE
chore: pin actions to commit SHAs

### DIFF
--- a/.github/workflows/publish-on-push.yml
+++ b/.github/workflows/publish-on-push.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
@@ -23,7 +23,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: 22.22.1
           registry-url: 'https://registry.npmjs.org/'


### PR DESCRIPTION
# Summary

- Pin `actions/checkout` from `@v6` to commit SHA `de0fac2e...` (v6)
- Pin `actions/setup-node` from `@v5` to commit SHA `a0853c24...` (v5)