### PR TITLE
fix: bump shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
+    "shell-quote": "^1.8.4",
     "ajv": ">=8.18.0",
     "glob": ">10.5.0",
     "minimatch": ">=10.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3626,10 +3626,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Adds shell-quote ^1.8.4 resolution to force the patched transitive version
- Resolves critical Dependabot alert #40 (GHSA shell-quote command injection)