### PR TITLE
fix: bump brace-expansion to 5.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
+    "brace-expansion@^5.0.5": "^5.0.7",
     "shell-quote": "^1.8.4",
     "esbuild": "^0.28.1",
     "ajv": ">=8.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,12 +1818,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Add brace-expansion@^5.0.5 → ^5.0.7 resolution to fix exponential-time DoS (#48, High)
- Only the 5.x line was in scope (vulnerable range 3.0.0–5.0.6); resolves to 5.0.7
- Build verified